### PR TITLE
Support CacheEvictOnCachePut and regionGroupOnCacheEvict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     testCompile group: 'org.hibernate', name: 'hibernate-testing', version: '5.4.27.Final'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.18.1'
     testCompile group: 'com.h2database', name: 'h2', version: '1.4.200'
+
+    implementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
 }
 tasks.test {
     useJUnit()

--- a/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusStorageConfig.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusStorageConfig.java
@@ -1,12 +1,17 @@
 package com.devookim.hibernatearcus.config;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 
 public class HibernateArcusStorageConfig {
 
     public final boolean enableCacheEvictOnCachePut;
+    public final HashSet<String> regionGroupOnCacheEvict;
 
     public HibernateArcusStorageConfig(Map<String, String> properties) {
         enableCacheEvictOnCachePut = Boolean.parseBoolean(properties.getOrDefault("hibernate.cache.arcus.enableCacheEvictOnCachePut", "false"));
+        regionGroupOnCacheEvict = new HashSet<>();
+        Collections.addAll(regionGroupOnCacheEvict, properties.getOrDefault("hibernate.cache.arcus.regionGroupOnCacheEvict", "").split(","));
     }
 }

--- a/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusStorageConfig.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusStorageConfig.java
@@ -1,0 +1,12 @@
+package com.devookim.hibernatearcus.config;
+
+import java.util.Map;
+
+public class HibernateArcusStorageConfig {
+
+    public final boolean cacheEvictOnCachePut;
+
+    public HibernateArcusStorageConfig(Map<String, String> properties) {
+        cacheEvictOnCachePut = Boolean.parseBoolean(properties.getOrDefault("hibernate.cache.arcus.cacheEvictOnCachePut", "false"));
+    }
+}

--- a/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusStorageConfig.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusStorageConfig.java
@@ -4,9 +4,9 @@ import java.util.Map;
 
 public class HibernateArcusStorageConfig {
 
-    public final boolean cacheEvictOnCachePut;
+    public final boolean enableCacheEvictOnCachePut;
 
     public HibernateArcusStorageConfig(Map<String, String> properties) {
-        cacheEvictOnCachePut = Boolean.parseBoolean(properties.getOrDefault("hibernate.cache.arcus.cacheEvictOnCachePut", "false"));
+        enableCacheEvictOnCachePut = Boolean.parseBoolean(properties.getOrDefault("hibernate.cache.arcus.enableCacheEvictOnCachePut", "false"));
     }
 }

--- a/src/main/java/com/devookim/hibernatearcus/config/RegionConfigUtil.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/RegionConfigUtil.java
@@ -1,0 +1,18 @@
+package com.devookim.hibernatearcus.config;
+
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.spi.access.AccessType;
+
+public class RegionConfigUtil {
+    public static boolean isEntityCaching(DomainDataRegionConfig regionConfig) {
+        return regionConfig.getEntityCaching().size() > 0;
+    }
+
+    public static AccessType getAccessTypeOfEntityCaching(DomainDataRegionConfig regionConfig) {
+        return isEntityCaching(regionConfig) ? regionConfig.getEntityCaching().get(0).getAccessType() : null;
+    }
+
+    public static String getEntityClassName(DomainDataRegionConfig regionConfig) {
+        return isEntityCaching(regionConfig) ? regionConfig.getEntityCaching().get(0).getNavigableRole().getNavigableName() : "";
+    }
+}

--- a/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusCacheKeysFactory.java
+++ b/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusCacheKeysFactory.java
@@ -31,7 +31,7 @@ public class HibernateArcusCacheKeysFactory extends DefaultCacheKeysFactory {
         }
     }
 
-    private static class EntityKey implements Serializable {
+    public static class EntityKey implements Serializable {
         private final String entityName;
         private final Object id;
 

--- a/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
+++ b/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
@@ -2,6 +2,7 @@ package com.devookim.hibernatearcus.factory;
 
 import com.devookim.hibernatearcus.client.HibernateArcusClientFactory;
 import com.devookim.hibernatearcus.config.ArcusClientConfig;
+import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
 import com.devookim.hibernatearcus.storage.DomainDataHibernateArcusStorageAccess;
 import com.devookim.hibernatearcus.storage.HibernateArcusStorageAccess;
 import com.devookim.hibernatearcus.storage.QueryCacheHibernateArcusStorageAccess;
@@ -30,6 +31,7 @@ public class HibernateArcusRegionFactory extends RegionFactoryTemplate {
     
     private HibernateArcusClientFactory hibernateArcusClientFactory;
     private CacheKeysFactory cacheKeysFactory;
+    private HibernateArcusStorageConfig storageConfig;
 
     @PostConstruct
     public void postConstruct() {
@@ -45,6 +47,7 @@ public class HibernateArcusRegionFactory extends RegionFactoryTemplate {
     protected void prepareForUse(SessionFactoryOptions settings, Map properties) throws CacheException {
 
         ArcusClientConfig arcusClientConfig = new ArcusClientConfig(properties);
+        storageConfig = new HibernateArcusStorageConfig(properties);
         this.hibernateArcusClientFactory = new HibernateArcusClientFactory(arcusClientConfig);
         StrategySelector selector = settings.getServiceRegistry().getService(StrategySelector.class);
         cacheKeysFactory = selector.resolveDefaultableStrategy(CacheKeysFactory.class,
@@ -82,7 +85,7 @@ public class HibernateArcusRegionFactory extends RegionFactoryTemplate {
 
     @Override
     protected DomainDataStorageAccess createDomainDataStorageAccess(DomainDataRegionConfig regionConfig, DomainDataRegionBuildingContext buildingContext) {
-        return new DomainDataHibernateArcusStorageAccess(getClientFactory(qualify(regionConfig.getRegionName())),  qualify(regionConfig.getRegionName()));
+        return new DomainDataHibernateArcusStorageAccess(getClientFactory(qualify(regionConfig.getRegionName())),  qualify(regionConfig.getRegionName()), storageConfig);
     }
 
     @Override

--- a/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
+++ b/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
@@ -87,7 +87,7 @@ public class HibernateArcusRegionFactory extends RegionFactoryTemplate {
         return new DomainDataHibernateArcusStorageAccess(getClientFactory(qualify(regionConfig.getRegionName())),
                 qualify(regionConfig.getRegionName()),
                 storageConfig,
-                regionConfig.getEntityCaching().get(0).getNavigableRole().getNavigableName());
+                regionConfig);
     }
 
     @Override

--- a/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
+++ b/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
@@ -3,6 +3,7 @@ package com.devookim.hibernatearcus.factory;
 import com.devookim.hibernatearcus.client.HibernateArcusClientFactory;
 import com.devookim.hibernatearcus.config.ArcusClientConfig;
 import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
+import com.devookim.hibernatearcus.config.RegionConfigUtil;
 import com.devookim.hibernatearcus.storage.DomainDataHibernateArcusStorageAccess;
 import com.devookim.hibernatearcus.storage.HibernateArcusStorageAccess;
 import com.devookim.hibernatearcus.storage.QueryCacheHibernateArcusStorageAccess;
@@ -85,7 +86,7 @@ public class HibernateArcusRegionFactory extends RegionFactoryTemplate {
 
     @Override
     protected DomainDataStorageAccess createDomainDataStorageAccess(DomainDataRegionConfig regionConfig, DomainDataRegionBuildingContext buildingContext) {
-        if (regionConfig.getEntityCaching().size() > 0 && regionConfig.getEntityCaching().get(0).getAccessType().equals(AccessType.READ_WRITE)) {
+        if (RegionConfigUtil.getAccessTypeOfEntityCaching(regionConfig) == AccessType.READ_WRITE) {
             return new ReadWriteAccessDomainDataStorageAccess(getClientFactory(qualify(regionConfig.getRegionName())),
                     qualify(regionConfig.getRegionName()),
                     storageConfig,

--- a/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
+++ b/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
@@ -7,7 +7,6 @@ import com.devookim.hibernatearcus.storage.DomainDataHibernateArcusStorageAccess
 import com.devookim.hibernatearcus.storage.HibernateArcusStorageAccess;
 import com.devookim.hibernatearcus.storage.QueryCacheHibernateArcusStorageAccess;
 import lombok.extern.slf4j.Slf4j;
-import net.spy.memcached.ArcusClientPool;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
@@ -85,7 +84,10 @@ public class HibernateArcusRegionFactory extends RegionFactoryTemplate {
 
     @Override
     protected DomainDataStorageAccess createDomainDataStorageAccess(DomainDataRegionConfig regionConfig, DomainDataRegionBuildingContext buildingContext) {
-        return new DomainDataHibernateArcusStorageAccess(getClientFactory(qualify(regionConfig.getRegionName())),  qualify(regionConfig.getRegionName()), storageConfig);
+        return new DomainDataHibernateArcusStorageAccess(getClientFactory(qualify(regionConfig.getRegionName())),
+                qualify(regionConfig.getRegionName()),
+                storageConfig,
+                regionConfig.getEntityCaching().get(0).getNavigableRole().getNavigableName());
     }
 
     @Override

--- a/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
+++ b/src/main/java/com/devookim/hibernatearcus/factory/HibernateArcusRegionFactory.java
@@ -6,6 +6,7 @@ import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
 import com.devookim.hibernatearcus.storage.DomainDataHibernateArcusStorageAccess;
 import com.devookim.hibernatearcus.storage.HibernateArcusStorageAccess;
 import com.devookim.hibernatearcus.storage.QueryCacheHibernateArcusStorageAccess;
+import com.devookim.hibernatearcus.storage.ReadWriteAccessDomainDataStorageAccess;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.SessionFactoryOptions;
@@ -84,6 +85,12 @@ public class HibernateArcusRegionFactory extends RegionFactoryTemplate {
 
     @Override
     protected DomainDataStorageAccess createDomainDataStorageAccess(DomainDataRegionConfig regionConfig, DomainDataRegionBuildingContext buildingContext) {
+        if (regionConfig.getEntityCaching().size() > 0 && regionConfig.getEntityCaching().get(0).getAccessType().equals(AccessType.READ_WRITE)) {
+            return new ReadWriteAccessDomainDataStorageAccess(getClientFactory(qualify(regionConfig.getRegionName())),
+                    qualify(regionConfig.getRegionName()),
+                    storageConfig,
+                    regionConfig);
+        }
         return new DomainDataHibernateArcusStorageAccess(getClientFactory(qualify(regionConfig.getRegionName())),
                 qualify(regionConfig.getRegionName()),
                 storageConfig,

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -1,13 +1,14 @@
 package com.devookim.hibernatearcus.storage;
 
 import com.devookim.hibernatearcus.client.HibernateArcusClientFactory;
+import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 @Slf4j
 public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorageAccess {
-    public DomainDataHibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName) {
+    public DomainDataHibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName, HibernateArcusStorageConfig config) {
         super(arcusClientFactory, regionName);
     }
 

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -2,16 +2,14 @@ package com.devookim.hibernatearcus.storage;
 
 import com.devookim.hibernatearcus.client.HibernateArcusClientFactory;
 import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
+import com.devookim.hibernatearcus.config.RegionConfigUtil;
 import com.devookim.hibernatearcus.factory.HibernateArcusCacheKeysFactory;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
-import java.time.Duration;
 import java.util.HashMap;
 
 @Slf4j
@@ -20,9 +18,7 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
 
     private final HibernateArcusStorageConfig storageAccessConfig;
     public final String entityClassName;
-    private final boolean isEntityCachingStorage;
     private final AccessType accessType;
-    private final Cache<AbstractReadWriteAccess.SoftLockImpl, Object> readWriteAccessLocks;
 
     public DomainDataHibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory,
                                                  String regionName,
@@ -30,15 +26,9 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
                                                  DomainDataRegionConfig regionConfig) {
         super(arcusClientFactory, regionName);
         this.storageAccessConfig = storageAccessConfig;
-        isEntityCachingStorage = regionConfig.getEntityCaching().size() > 0;
-        this.entityClassName = isEntityCachingStorage ? regionConfig.getEntityCaching().get(0).getNavigableRole().getNavigableName() : "";
-        this.accessType = isEntityCachingStorage ? regionConfig.getEntityCaching().get(0).getAccessType() : null;
+        this.entityClassName = RegionConfigUtil.getEntityClassName(regionConfig);
+        this.accessType = RegionConfigUtil.getAccessTypeOfEntityCaching(regionConfig);
         domainDataStorageAccesses.put(regionName, this);
-        readWriteAccessLocks = CacheBuilder.newBuilder()
-                .expireAfterWrite(Duration.ofSeconds(10))
-                .concurrencyLevel(1000)
-                .build();
-
     }
 
     @Override

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -56,12 +56,9 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
 
     @Override
     public void putIntoCache(Object key, Object value, SharedSessionContractImplementor session) {
-        if (storageAccessConfig.enableCacheEvictOnCachePut &&
-                (accessType == AccessType.READ_WRITE && value instanceof AbstractReadWriteAccess.SoftLockImpl && readWriteAccessLocks.getIfPresent(value) == null)
-                || (accessType != AccessType.READ_WRITE && contains(key))) {
-            if (accessType == AccessType.READ_WRITE) {
-                readWriteAccessLocks.put((AbstractReadWriteAccess.SoftLockImpl) value, key);
-            }
+        if (accessType != AccessType.READ_WRITE
+                && storageAccessConfig.enableCacheEvictOnCachePut
+                && contains(key)) {
             log.debug("enableCacheEvictOnCachePut enabled. key: {}", key);
             evictData(key);
         }

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -2,17 +2,24 @@ package com.devookim.hibernatearcus.storage;
 
 import com.devookim.hibernatearcus.client.HibernateArcusClientFactory;
 import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
+import com.devookim.hibernatearcus.factory.HibernateArcusCacheKeysFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
+import java.util.HashMap;
+
 @Slf4j
 public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorageAccess {
+    private static final HashMap<String, DomainDataHibernateArcusStorageAccess> domainDataStorageAccesses = new HashMap<>();
     private final HibernateArcusStorageConfig storageAccessConfig;
+    public final String entityClassName;
 
-    public DomainDataHibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName, HibernateArcusStorageConfig storageAccessConfig) {
+    public DomainDataHibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName, HibernateArcusStorageConfig storageAccessConfig, String entityClassName) {
         super(arcusClientFactory, regionName);
         this.storageAccessConfig = storageAccessConfig;
+        this.entityClassName = entityClassName;
+        domainDataStorageAccesses.put(regionName, this);
     }
 
     @Override

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -8,8 +8,11 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 @Slf4j
 public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorageAccess {
-    public DomainDataHibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName, HibernateArcusStorageConfig config) {
+    private final HibernateArcusStorageConfig storageAccessConfig;
+
+    public DomainDataHibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName, HibernateArcusStorageConfig storageAccessConfig) {
         super(arcusClientFactory, regionName);
+        this.storageAccessConfig = storageAccessConfig;
     }
 
     @Override
@@ -27,11 +30,19 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
 
     @Override
     public void putIntoCache(Object key, Object value, SharedSessionContractImplementor session) {
+        if (storageAccessConfig.enableCacheEvictOnCachePut) {
+            evictData(key);
+        }
         super.putIntoCache(key, value, session);
         if (value instanceof AbstractReadWriteAccess.SoftLockImpl) {
             log.trace("cacheLock key: {} lock: {}", generateKey(key), value);
         } else {
             log.debug("cachePut key: {} value: {}", generateKey(key), value);
         }
+    }
+
+    @Override
+    public void evictData(Object key) {
+        super.evictData(key);
     }
 }

--- a/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
@@ -12,7 +12,7 @@ import java.time.Duration;
 
 public class ReadWriteAccessDomainDataStorageAccess extends DomainDataHibernateArcusStorageAccess {
     private final Cache<AbstractReadWriteAccess.SoftLockImpl, Object> readWriteAccessLocks;
-    private HibernateArcusStorageConfig storageAccessConfig;
+    private final HibernateArcusStorageConfig storageAccessConfig;
 
     public ReadWriteAccessDomainDataStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName, HibernateArcusStorageConfig storageAccessConfig, DomainDataRegionConfig regionConfig) {
         super(arcusClientFactory, regionName, storageAccessConfig, regionConfig);

--- a/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
@@ -1,0 +1,36 @@
+package com.devookim.hibernatearcus.storage;
+
+import com.devookim.hibernatearcus.client.HibernateArcusClientFactory;
+import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+import java.time.Duration;
+
+public class ReadWriteAccessDomainDataStorageAccess extends DomainDataHibernateArcusStorageAccess {
+    private final Cache<AbstractReadWriteAccess.SoftLockImpl, Object> readWriteAccessLocks;
+    private HibernateArcusStorageConfig storageAccessConfig;
+
+    public ReadWriteAccessDomainDataStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName, HibernateArcusStorageConfig storageAccessConfig, DomainDataRegionConfig regionConfig) {
+        super(arcusClientFactory, regionName, storageAccessConfig, regionConfig);
+        this.storageAccessConfig = storageAccessConfig;
+        readWriteAccessLocks = CacheBuilder.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(10))
+                .concurrencyLevel(1000)
+                .build();
+    }
+
+    @Override
+    public void putIntoCache(Object key, Object value, SharedSessionContractImplementor session) {
+        if (storageAccessConfig.enableCacheEvictOnCachePut
+                && value instanceof AbstractReadWriteAccess.SoftLockImpl
+                && readWriteAccessLocks.getIfPresent(value) == null) {
+            evictData(key);
+            readWriteAccessLocks.put((AbstractReadWriteAccess.SoftLockImpl) value, key);
+        }
+        super.putIntoCache(key, value, session);
+    }
+}

--- a/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
@@ -19,6 +19,7 @@ public class ReadWriteAccessDomainDataStorageAccess extends DomainDataHibernateA
         this.storageAccessConfig = storageAccessConfig;
         readWriteAccessLocks = CacheBuilder.newBuilder()
                 .expireAfterWrite(Duration.ofSeconds(10))
+                .maximumSize(10000)
                 .concurrencyLevel(1000)
                 .build();
     }

--- a/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
@@ -1,0 +1,159 @@
+package hibernate;
+
+import com.devookim.hibernatearcus.factory.HibernateArcusRegionFactory;
+import lombok.NoArgsConstructor;
+import org.hibernate.Session;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+
+public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctionalTestCase {
+
+    private final String collectionCacheRegionName = "hibernate.CollectionCacheTest$ParentDomainData.children";
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class[]{DomainRegionOne.class, DomainRegionTwo.class};
+    }
+
+    @Override
+    protected void configure(Configuration cfg) {
+        super.configure(cfg);
+        cfg.setProperty(Environment.DRIVER, org.h2.Driver.class.getName());
+        cfg.setProperty(Environment.URL, "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;");
+        cfg.setProperty(Environment.GENERATE_STATISTICS, "true");
+
+        cfg.setProperty(Environment.SHOW_SQL, "true");
+        cfg.setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true");
+        cfg.setProperty(Environment.CACHE_REGION_FACTORY, HibernateArcusRegionFactory.class.getName());
+        cfg.setProperty("hibernate.cache.arcus.enableCacheEvictOnCachePut", "true");
+        cfg.setProperty("hibernate.cache.arcus.regionGroupOnCacheEvict", DomainRegionOne.regionName + "," + DomainRegionTwo.regionName);
+    }
+
+    @Before
+    public void before() {
+        sessionFactory().getStatistics().clear();
+    }
+
+    @Test
+    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsEvicted_thenDomainRegionTwoWithSameIdIsEvictedTogether() {
+        CacheRegionStatistics regionOneStat = sessionFactory()
+                .getStatistics().getDomainDataRegionStatistics(DomainRegionOne.regionName);
+        CacheRegionStatistics regionTwoStat = sessionFactory()
+                .getStatistics().getDomainDataRegionStatistics(DomainRegionTwo.regionName);
+        final long id = System.currentTimeMillis();
+        Session s = openSession();
+        s.beginTransaction();
+        DomainRegionOne regionOne = new DomainRegionOne(id);
+        DomainRegionTwo regionTwo = new DomainRegionTwo(id);
+        s.save(regionOne);
+        s.save(regionTwo);
+        s.flush();
+        s.getTransaction().commit();
+        s.close();
+        System.out.println("============================");
+
+        assertEquals(1, regionOneStat.getPutCount());
+        assertEquals(0, regionOneStat.getHitCount());
+        assertEquals(1, regionTwoStat.getPutCount());
+
+        s = openSession();
+        s.beginTransaction();
+        DomainRegionOne domainRegionOneFromCache = s.get(DomainRegionOne.class, id);
+        s.delete(domainRegionOneFromCache);
+        s.getTransaction().commit();
+        s.close();
+        System.out.println("============================");
+
+        assertEquals(1, regionOneStat.getHitCount());
+        assertEquals(0, regionTwoStat.getMissCount());
+
+        s = openSession();
+        s.beginTransaction();
+        s.get(DomainRegionTwo.class, id);
+        s.getTransaction().commit();
+        s.close();
+        assertEquals(1, regionTwoStat.getMissCount());
+    }
+
+    @Test
+    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsUpdated() {
+        CacheRegionStatistics regionOneStat = sessionFactory()
+                .getStatistics().getDomainDataRegionStatistics(DomainRegionOne.regionName);
+        CacheRegionStatistics regionTwoStat = sessionFactory()
+                .getStatistics().getDomainDataRegionStatistics(DomainRegionTwo.regionName);
+        final long id = System.currentTimeMillis();
+        Session s = openSession();
+        s.beginTransaction();
+        DomainRegionOne regionOne = new DomainRegionOne(id);
+        DomainRegionTwo regionTwo = new DomainRegionTwo(id);
+        s.save(regionOne);
+        s.save(regionTwo);
+        s.flush();
+        s.getTransaction().commit();
+        s.close();
+        System.out.println("============================");
+
+        assertEquals(1, regionOneStat.getPutCount());
+        assertEquals(1, regionTwoStat.getPutCount());
+
+        s = openSession();
+        s.beginTransaction();
+        DomainRegionOne domainRegionOneFromCache = s.get(DomainRegionOne.class, id);
+        domainRegionOneFromCache.value = "updated-value";
+        s.update(domainRegionOneFromCache);
+        s.getTransaction().commit();
+        s.close();
+        System.out.println("============================");
+
+        assertEquals(1, regionOneStat.getHitCount());
+        assertEquals(0, regionTwoStat.getMissCount());
+
+        s = openSession();
+        s.beginTransaction();
+        s.get(DomainRegionTwo.class, id);
+        s.getTransaction().commit();
+        s.close();
+
+        assertEquals(1, regionTwoStat.getMissCount());
+    }
+
+    @Entity
+    @NoArgsConstructor
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = DomainRegionOne.regionName)
+    public static class DomainRegionOne implements Serializable {
+        public static final String regionName = "DomainRegionOne";
+        public String value = "";
+        @Id
+        Long id;
+
+        public DomainRegionOne(Long id) {
+            this.id = id;
+        }
+    }
+
+    @Entity
+    @NoArgsConstructor
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = DomainRegionTwo.regionName)
+    public static class DomainRegionTwo implements Serializable {
+        public static final String regionName = "DomainRegionTwo";
+
+        @Id
+        long id;
+
+        public DomainRegionTwo(long id) {
+            this.id = id;
+        }
+    }
+}

--- a/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
@@ -47,7 +47,7 @@ public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctional
     }
 
     @Test
-    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsEvicted_thenDomainRegionTwoWithSameIdIsEvictedTogether() {
+    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsDeleted_thenDomainRegionTwoCacheWithSameIdIsEvicted() {
         CacheRegionStatistics regionOneStat = sessionFactory()
                 .getStatistics().getDomainDataRegionStatistics(DomainRegionOne.regionName);
         CacheRegionStatistics regionTwoStat = sessionFactory()
@@ -88,7 +88,7 @@ public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctional
     }
 
     @Test
-    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsUpdated() {
+    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsUpdated_thenDomainRegionTwoCacheWithSameIdIsEvicted() {
         CacheRegionStatistics regionOneStat = sessionFactory()
                 .getStatistics().getDomainDataRegionStatistics(DomainRegionOne.regionName);
         CacheRegionStatistics regionTwoStat = sessionFactory()

--- a/src/test/java/hibernate/RegionGroupTest.java
+++ b/src/test/java/hibernate/RegionGroupTest.java
@@ -1,0 +1,111 @@
+package hibernate;
+
+import com.devookim.hibernatearcus.factory.HibernateArcusRegionFactory;
+import lombok.NoArgsConstructor;
+import org.hibernate.Session;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+
+public class RegionGroupTest extends BaseCoreFunctionalTestCase {
+
+    private final String collectionCacheRegionName = "hibernate.CollectionCacheTest$ParentDomainData.children";
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class[]{DomainRegionOne.class, DomainRegionTwo.class};
+    }
+
+    @Override
+    protected void configure(Configuration cfg) {
+        super.configure(cfg);
+        cfg.setProperty(Environment.DRIVER, org.h2.Driver.class.getName());
+        cfg.setProperty(Environment.URL, "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;");
+        cfg.setProperty(Environment.GENERATE_STATISTICS, "true");
+
+        cfg.setProperty(Environment.SHOW_SQL, "true");
+        cfg.setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true");
+        cfg.setProperty(Environment.CACHE_REGION_FACTORY, HibernateArcusRegionFactory.class.getName());
+        cfg.setProperty("hibernate.cache.arcus.enableCacheEvictOnCachePut", "true");
+        cfg.setProperty("hibernate.cache.arcus.regionGroupOnCacheEvict", DomainRegionOne.regionName + "," + DomainRegionTwo.regionName);
+    }
+
+    @Before
+    public void before() {
+        sessionFactory().getStatistics().clear();
+    }
+
+    @Test
+    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsEvicted_thenDomainRegionTwoWithSameIdIsEvictedTogether() {
+        CacheRegionStatistics regionOneStat = sessionFactory()
+                .getStatistics().getDomainDataRegionStatistics(DomainRegionOne.regionName);
+        CacheRegionStatistics regionTwoStat = sessionFactory()
+                .getStatistics().getDomainDataRegionStatistics(DomainRegionTwo.regionName);
+        final long id = System.currentTimeMillis();
+        Session s = openSession();
+        s.beginTransaction();
+        DomainRegionOne regionOne = new DomainRegionOne(id);
+        DomainRegionTwo regionTwo = new DomainRegionTwo(id);
+        s.save(regionOne);
+        s.save(regionTwo);
+        s.flush();
+        s.getTransaction().commit();
+        s.close();
+
+        assertEquals(1, regionOneStat.getPutCount());
+        assertEquals(1, regionTwoStat.getPutCount());
+
+        s = openSession();
+        s.beginTransaction();
+        s.delete(regionOne);
+        s.getTransaction().commit();
+        s.close();
+
+        assertEquals(0, regionTwoStat.getMissCount());
+        s = openSession();
+        s.beginTransaction();
+        s.get(DomainRegionTwo.class, id);
+        s.getTransaction().commit();
+        s.close();
+        assertEquals(1, regionTwoStat.getMissCount());
+    }
+
+    @Entity
+    @NoArgsConstructor
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = DomainRegionOne.regionName)
+    public static class DomainRegionOne implements Serializable {
+        public static final String regionName = "DomainRegionOne";
+
+        @Id
+        Long id;
+
+        public DomainRegionOne(Long id) {
+            this.id = id;
+        }
+    }
+
+    @Entity
+    @NoArgsConstructor
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = DomainRegionTwo.regionName)
+    public static class DomainRegionTwo implements Serializable {
+        public static final String regionName = "DomainRegionTwo";
+
+        @Id
+        long id;
+
+        public DomainRegionTwo(long id) {
+            this.id = id;
+        }
+    }
+}

--- a/src/test/java/hibernate/TransactionAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/TransactionAccessDomainDataRegionGroupTest.java
@@ -47,7 +47,7 @@ public class TransactionAccessDomainDataRegionGroupTest extends BaseCoreFunction
     }
 
     @Test
-    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsEvicted_thenDomainRegionTwoWithSameIdIsEvictedTogether() {
+    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsDeleted_thenDomainRegionTwoCacheWithSameIdIsEvicted() {
         CacheRegionStatistics regionOneStat = sessionFactory()
                 .getStatistics().getDomainDataRegionStatistics(DomainRegionOne.regionName);
         CacheRegionStatistics regionTwoStat = sessionFactory()
@@ -87,7 +87,7 @@ public class TransactionAccessDomainDataRegionGroupTest extends BaseCoreFunction
     }
 
     @Test
-    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsUpdated() {
+    public void testCacheEvictOnCachePut_whenADomainRegionOneEntityIsUpdated_thenDomainRegionTwoCacheWithSameIdIsEvicted() {
         CacheRegionStatistics regionOneStat = sessionFactory()
                 .getStatistics().getDomainDataRegionStatistics(DomainRegionOne.regionName);
         CacheRegionStatistics regionTwoStat = sessionFactory()

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration scan="true" scanPeriod="30 seconds">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <Pattern>%d{HH:mm:ss} [%thread][%-5level] %logger{36}.%M - %msg%n</Pattern>
+            <Pattern>%d{HH:mm:ss:ns} [%thread][%-5level] %logger{36}.%M - %msg%n</Pattern>
         </encoder>
     </appender>
     <logger name="com" level="TRACE"/>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration scan="true" scanPeriod="30 seconds">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <Pattern>%d{HH:mm:ss:ns} [%thread][%-5level] %logger{36}.%M - %msg%n</Pattern>
+            <Pattern>%d{HH:mm:ss:ms} [%thread][%-5level] %logger{36}.%M - %msg%n</Pattern>
         </encoder>
     </appender>
     <logger name="com" level="TRACE"/>


### PR DESCRIPTION
## Motivation
[Issue: CacheEvict on CachePut is optional property and multiple cache region entities are evicted together](https://github.com/Kims-DeveloperGroup/hibernate-arcus/issues/7)

## Major Changes


### When enableCacheEvictOnCachePut is set to true, DomainData a cache item/items are evicted before cachePut.

1) _**ReadWriteAccessDomainDataStorageAccess**_ newly created to access read-write access entityCaching
 _ReadWriteAccessDomainDataStorageAccess_ evicts a cache item before cachePut.
Note: Delete calls cacheLock twice before and after calling delete-query. Only on the first cacheLock, cacheEvict is executed.

2) **_DomainDataHibernateArcusStorageAccess_** evicts a cache item before cachePut and if a cacheItme with a given id exists in a cache storage.

3) Multiple cacheItem eviction on cachePut are executed when  _regionGroupOnCacheEvict_ is specified

## Minor Changes
1) _HibernateArcusStorageConfig_ newly created
2) _RegionConfigUtil_ newly created


### New properties
```
hibernate.cache.arcus.enableCacheEvictOnCachePut (default: false)
hibernate.cache.arcus.regionGroupOnCacheEvict (default: "") //example region1, region2.....
```
Note: _regionGroupOnCacheEvict_ should be configured with _enableCacheEvictOnCachePut_ set to true