### PR TITLE
[ISSUE 7] ReadWriteAccessDomainDataStorageAccess checks transaction status for cacheEvict on cachePut

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ dependencies {
     testCompile group: 'org.hibernate', name: 'hibernate-testing', version: '5.4.27.Final'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.18.1'
     testCompile group: 'com.h2database', name: 'h2', version: '1.4.200'
-
-    implementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
 }
 tasks.test {
     useJUnit()

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -66,8 +66,10 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
         if (storageAccessConfig.regionGroupOnCacheEvict.contains(super.CACHE_REGION) && storageAccessConfig.enableCacheEvictOnCachePut) {
             String id = key.toString().split("#")[1];
             log.debug("regionGroupOnCacheEvict contains region: {}, id: {}", CACHE_REGION, id);
-            domainDataStorageAccesses.forEach((s, storageAccess) -> {
-                storageAccess.evictDataOnRegionGroupCacheEvict(new HibernateArcusCacheKeysFactory.EntityKey(storageAccess.entityClassName, id));
+            domainDataStorageAccesses.forEach((region, storageAccess) -> {
+                if (!region.equals(this.CACHE_REGION) || accessType != AccessType.READ_WRITE) {
+                    storageAccess.evictDataOnRegionGroupCacheEvict(new HibernateArcusCacheKeysFactory.EntityKey(storageAccess.entityClassName, id));
+                }
             });
         } else {
             super.evictData(key);

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 
 @Slf4j
 public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorageAccess {
-    private static final HashMap<String, DomainDataHibernateArcusStorageAccess> domainDataStorageAccesses = new HashMap<>();
+    protected static final HashMap<String, DomainDataHibernateArcusStorageAccess> domainDataStorageAccesses = new HashMap<>();
 
     private final HibernateArcusStorageConfig storageAccessConfig;
     public final String entityClassName;
@@ -63,14 +63,12 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
 
     @Override
     public void evictData(Object key) {
-        if (storageAccessConfig.regionGroupOnCacheEvict.contains(super.CACHE_REGION) && storageAccessConfig.enableCacheEvictOnCachePut) {
+        if (storageAccessConfig.regionGroupOnCacheEvict.contains(super.CACHE_REGION)
+                && storageAccessConfig.enableCacheEvictOnCachePut) {
             String id = key.toString().split("#")[1];
             log.debug("regionGroupOnCacheEvict contains region: {}, id: {}", CACHE_REGION, id);
-            domainDataStorageAccesses.forEach((region, storageAccess) -> {
-                if (!region.equals(this.CACHE_REGION) || accessType != AccessType.READ_WRITE) {
-                    storageAccess.evictDataOnRegionGroupCacheEvict(new HibernateArcusCacheKeysFactory.EntityKey(storageAccess.entityClassName, id));
-                }
-            });
+            domainDataStorageAccesses.forEach((region, storageAccess) ->
+                    storageAccess.evictDataOnRegionGroupCacheEvict(new HibernateArcusCacheKeysFactory.EntityKey(storageAccess.entityClassName, id)));
         } else {
             super.evictData(key);
         }

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -63,8 +63,8 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
 
     @Override
     public void evictData(Object key) {
-        if (storageAccessConfig.regionGroupOnCacheEvict.contains(super.CACHE_REGION)
-                && storageAccessConfig.enableCacheEvictOnCachePut) {
+        if (storageAccessConfig.enableCacheEvictOnCachePut
+                && storageAccessConfig.regionGroupOnCacheEvict.contains(CACHE_REGION)) {
             String id = key.toString().split("#")[1];
             log.debug("regionGroupOnCacheEvict contains region: {}, id: {}", CACHE_REGION, id);
             domainDataStorageAccesses.forEach((region, storageAccess) ->
@@ -75,7 +75,7 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
     }
 
     public void evictDataOnRegionGroupCacheEvict(Object key) {
-        if (storageAccessConfig.regionGroupOnCacheEvict.contains(super.CACHE_REGION)) {
+        if (storageAccessConfig.regionGroupOnCacheEvict.contains(CACHE_REGION)) {
             log.debug("cacheEvict {} by regionGroupOnCacheEvict", key);
             super.evictData(key);
         }

--- a/src/main/java/com/devookim/hibernatearcus/storage/HibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/HibernateArcusStorageAccess.java
@@ -72,7 +72,7 @@ public class HibernateArcusStorageAccess implements DomainDataStorageAccess {
         String generatedKey = generateKey(key);
         try {
             Object result = arcusClientFactory.getClientPool().get(generatedKey);
-            log.info("containKey for {} contains: {}", generatedKey, result != null);
+            log.trace("containKey for {} contains: {}", generatedKey, result != null);
             return result != null;
         } catch (Exception e) {
             log.error("fallbackEnabled: {} key: {} errorMsg: {}", arcusClientFactory.fallbackEnabled, generatedKey, e.getMessage());

--- a/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
@@ -2,36 +2,34 @@ package com.devookim.hibernatearcus.storage;
 
 import com.devookim.hibernatearcus.client.HibernateArcusClientFactory;
 import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
 import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
 
-import java.time.Duration;
-
+@Slf4j
 public class ReadWriteAccessDomainDataStorageAccess extends DomainDataHibernateArcusStorageAccess {
-    private final Cache<AbstractReadWriteAccess.SoftLockImpl, Object> readWriteAccessLocks;
     private final HibernateArcusStorageConfig storageAccessConfig;
 
     public ReadWriteAccessDomainDataStorageAccess(HibernateArcusClientFactory arcusClientFactory, String regionName, HibernateArcusStorageConfig storageAccessConfig, DomainDataRegionConfig regionConfig) {
         super(arcusClientFactory, regionName, storageAccessConfig, regionConfig);
         this.storageAccessConfig = storageAccessConfig;
-        readWriteAccessLocks = CacheBuilder.newBuilder()
-                .expireAfterWrite(Duration.ofSeconds(10))
-                .maximumSize(10000)
-                .concurrencyLevel(1000)
-                .build();
     }
 
     @Override
     public void putIntoCache(Object key, Object value, SharedSessionContractImplementor session) {
         if (storageAccessConfig.enableCacheEvictOnCachePut
                 && value instanceof AbstractReadWriteAccess.SoftLockImpl
-                && readWriteAccessLocks.getIfPresent(value) == null) {
+                && isTransactionActive(session)) {
+            log.debug("enableCacheEvictOnCachePut enabled. key: {}", key);
             evictData(key);
-            readWriteAccessLocks.put((AbstractReadWriteAccess.SoftLockImpl) value, key);
         }
         super.putIntoCache(key, value, session);
+    }
+
+    private boolean isTransactionActive(SharedSessionContractImplementor session) {
+        return session.getTransaction() != null
+                && session.getTransaction().getStatus().equals(TransactionStatus.ACTIVE);
     }
 }

--- a/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
@@ -2,6 +2,7 @@ package com.devookim.hibernatearcus.storage;
 
 import com.devookim.hibernatearcus.client.HibernateArcusClientFactory;
 import com.devookim.hibernatearcus.config.HibernateArcusStorageConfig;
+import com.devookim.hibernatearcus.factory.HibernateArcusCacheKeysFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
 import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
@@ -26,6 +27,21 @@ public class ReadWriteAccessDomainDataStorageAccess extends DomainDataHibernateA
             evictData(key);
         }
         super.putIntoCache(key, value, session);
+    }
+
+    @Override
+    public void evictData(Object key) {
+        if (storageAccessConfig.regionGroupOnCacheEvict.contains(super.CACHE_REGION) && storageAccessConfig.enableCacheEvictOnCachePut) {
+            String id = key.toString().split("#")[1];
+            log.debug("regionGroupOnCacheEvict contains region: {}, id: {}", CACHE_REGION, id);
+            domainDataStorageAccesses.forEach((region, storageAccess) -> {
+                if (!region.equals(this.CACHE_REGION)) {
+                    storageAccess.evictDataOnRegionGroupCacheEvict(new HibernateArcusCacheKeysFactory.EntityKey(storageAccess.entityClassName, id));
+                }
+            });
+        } else {
+            super.evictData(key);
+        }
     }
 
     private boolean isTransactionActive(SharedSessionContractImplementor session) {

--- a/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/ReadWriteAccessDomainDataStorageAccess.java
@@ -31,11 +31,12 @@ public class ReadWriteAccessDomainDataStorageAccess extends DomainDataHibernateA
 
     @Override
     public void evictData(Object key) {
-        if (storageAccessConfig.regionGroupOnCacheEvict.contains(super.CACHE_REGION) && storageAccessConfig.enableCacheEvictOnCachePut) {
+        if (storageAccessConfig.enableCacheEvictOnCachePut &&
+                storageAccessConfig.regionGroupOnCacheEvict.contains(CACHE_REGION)) {
             String id = key.toString().split("#")[1];
             log.debug("regionGroupOnCacheEvict contains region: {}, id: {}", CACHE_REGION, id);
             domainDataStorageAccesses.forEach((region, storageAccess) -> {
-                if (!region.equals(this.CACHE_REGION)) {
+                if (!region.equals(CACHE_REGION)) {
                     storageAccess.evictDataOnRegionGroupCacheEvict(new HibernateArcusCacheKeysFactory.EntityKey(storageAccess.entityClassName, id));
                 }
             });

--- a/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.assertEquals;
 
 public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctionalTestCase {
 
-    private final String collectionCacheRegionName = "hibernate.CollectionCacheTest$ParentDomainData.children";
-
     @Override
     protected Class<?>[] getAnnotatedClasses() {
         return new Class[]{DomainRegionOne.class, DomainRegionTwo.class};

--- a/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
@@ -215,7 +215,6 @@ public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctional
         DomainRegionTwo domainRegionTwoFromCache = s.get(DomainRegionTwo.class, id);
         domainRegionTwoFromCache.value = "updated_value";
         s.update(domainRegionTwoFromCache);
-        System.out.println("Commit");
         s.flush();
         s.getTransaction().commit();
         s.close();

--- a/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
@@ -17,6 +17,7 @@ import javax.persistence.Id;
 import java.io.Serializable;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctionalTestCase {
 
@@ -81,8 +82,10 @@ public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctional
         s = openSession();
         s.beginTransaction();
         s.get(DomainRegionTwo.class, id);
+        DomainRegionOne domainRegionOneAfterDelete = s.get(DomainRegionOne.class, id);
         s.getTransaction().commit();
         s.close();
+        assertNull(domainRegionOneAfterDelete);
         assertEquals(1, regionTwoStat.getMissCount());
     }
 

--- a/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
@@ -182,10 +182,11 @@ public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctional
 
     /**
      * When updates of regionOne and regionTwo are executed in a transaction, the cache items of both region entities are put.
-     * As a result, the next get operation of both will get cacheHit
+     * However the second update evicts the cache item of the first update.
+     * As a result, the next get operation of regionOne will get cacheMiss, and regionTwo will get cacheHit
      */
     @Test
-    public void testCacheEvictOnCachePut_whenDomainRegionOneEntityAndDomainRegionOneEntityAreUpdatedInTheSameTransaction_thenDomainRegionOneAndDomainRegionTwoShouldBeCacheHit() {
+    public void testCacheEvictOnCachePut_whenDomainRegionOneEntityAndDomainRegionOneEntityAreUpdatedInTheSameTransaction_thenDomainRegionOneShouldBeCacheMissAndDomainRegionTwoShouldBeCacheHit() {
         CacheRegionStatistics regionOneStat = sessionFactory()
                 .getStatistics().getDomainDataRegionStatistics(DomainRegionOne.regionName);
         CacheRegionStatistics regionTwoStat = sessionFactory()
@@ -228,6 +229,8 @@ public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctional
         s.get(DomainRegionTwo.class, id);
         s.getTransaction().commit();
         s.close();
+        assertEquals(1, regionOneStat.getHitCount());
+        assertEquals(1, regionOneStat.getMissCount());
         assertEquals(2, regionTwoStat.getHitCount());
     }
 

--- a/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/ReadWriteAccessDomainDataRegionGroupTest.java
@@ -132,9 +132,11 @@ public class ReadWriteAccessDomainDataRegionGroupTest extends BaseCoreFunctional
 
         s = openSession();
         s.beginTransaction();
+        DomainRegionOne domainRegionOneAfterDelete = s.get(DomainRegionOne.class, id);
         s.get(DomainRegionTwo.class, id);
         s.getTransaction().commit();
         s.close();
+        assertNull(domainRegionOneAfterDelete);
         assertEquals(1, regionTwoStat.getHitCount());
         assertEquals(1, regionTwoStat.getMissCount());
     }

--- a/src/test/java/hibernate/TransactionAccessDomainDataRegionGroupTest.java
+++ b/src/test/java/hibernate/TransactionAccessDomainDataRegionGroupTest.java
@@ -17,6 +17,7 @@ import javax.persistence.Id;
 import java.io.Serializable;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TransactionAccessDomainDataRegionGroupTest extends BaseCoreFunctionalTestCase {
 
@@ -80,9 +81,11 @@ public class TransactionAccessDomainDataRegionGroupTest extends BaseCoreFunction
         assertEquals(0, regionTwoStat.getMissCount());
         s = openSession();
         s.beginTransaction();
+        DomainRegionOne domainRegionOneAfterDelete = s.get(DomainRegionOne.class, id);
         s.get(DomainRegionTwo.class, id);
         s.getTransaction().commit();
         s.close();
+        assertNull(domainRegionOneAfterDelete);
         assertEquals(1, regionTwoStat.getMissCount());
     }
 
@@ -128,9 +131,11 @@ public class TransactionAccessDomainDataRegionGroupTest extends BaseCoreFunction
 
         s = openSession();
         s.beginTransaction();
+        DomainRegionOne domainRegionOneAfterDelete = s.get(DomainRegionOne.class, id);
         s.get(DomainRegionTwo.class, id);
         s.getTransaction().commit();
         s.close();
+        assertNull(domainRegionOneAfterDelete);
         assertEquals(1, regionTwoStat.getMissCount());
     }
 


### PR DESCRIPTION
Changes: 
- Remove guva LoadingCache in ReadWriteAccessDomainDataStorageAccess
- Check transaction status in _ReadWriteAccessDomainDataStorageAccess.putInToCache_ whether to evict cache or not