### PR TITLE
[Issues/11] TTL of DomainData EntityCaching is configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group='com.github.kims-developergroup'
 archivesBaseName='hibernate-arcus'
-version='1.2.0-RELEASE'
+version='1.2.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group='com.github.kims-developergroup'
 archivesBaseName='hibernate-arcus'
-version='1.2.0-SNAPSHOT'
+version='1.2.0-RELEASE'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/devookim/hibernatearcus/config/ArcusClientConfig.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/ArcusClientConfig.java
@@ -7,31 +7,36 @@ import net.spy.memcached.ConnectionFactoryBuilder;
 
 import java.util.Map;
 
+import static com.devookim.hibernatearcus.config.HibernateArcusProperties.*;
+
 @Slf4j
 public class ArcusClientConfig {
     public final boolean fallbackEnabled;
     public final boolean initFallbackMode;
     public final int healthCheckIntervalInSec;
+    public final int domainDataTTL;
     private final int poolSize;
     private final Map<String, String> properties;
     private final String host;
     private final String serviceCode;
 
     public ArcusClientConfig(Map<String, String> properties) {
-        this.host = properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_HOST, "localhost:2181");
-        this.serviceCode = properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_SERVICE_CODE, "");
-        this.poolSize = Integer.parseInt(properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_POOL_SIZE, "1"));
-        this.fallbackEnabled = Boolean.parseBoolean(properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_FALLBACK_ENABLED, "true"));
-        this.initFallbackMode = Boolean.parseBoolean(properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_INIT_FALLBACK_MODE, "false"));
-        this.healthCheckIntervalInSec = Integer.parseInt(properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_HEALTH_CHECK_INTERVAL_IN_SEC, "10"));
+        this.host = properties.getOrDefault(HIBERNATE_CACHE_ARCUS_HOST, "localhost:2181");
+        this.serviceCode = properties.getOrDefault(HIBERNATE_CACHE_ARCUS_SERVICE_CODE, "");
+        this.poolSize = Integer.parseInt(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_POOL_SIZE, "1"));
+        this.domainDataTTL = Integer.parseInt(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_DOMAIN_DATA_TTL, "0"));
+
+        this.fallbackEnabled = Boolean.parseBoolean(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_FALLBACK_ENABLED, "true"));
+        this.initFallbackMode = Boolean.parseBoolean(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_INIT_FALLBACK_MODE, "false"));
+        this.healthCheckIntervalInSec = Integer.parseInt(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_HEALTH_CHECK_INTERVAL_IN_SEC, "10"));
         this.properties = properties;
     }
 
     public ArcusClientPool createArcusClientPool() {
         log.info("Creating arcus client pool");
         ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
-        cfb.setMaxReconnectDelay(Long.parseLong(properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_RECONNECT_INTERVAL_IN_SEC, "10000")));
-        cfb.setOpTimeout(Long.parseLong(properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_OP_TIMEOUT, "10000")));
+        cfb.setMaxReconnectDelay(Long.parseLong(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_RECONNECT_INTERVAL_IN_SEC, "10000")));
+        cfb.setOpTimeout(Long.parseLong(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_OP_TIMEOUT, "10000")));
         return ArcusClient.createArcusClientPool(
                 host,
                 serviceCode,

--- a/src/main/java/com/devookim/hibernatearcus/config/ArcusClientConfig.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/ArcusClientConfig.java
@@ -14,7 +14,6 @@ public class ArcusClientConfig {
     public final boolean fallbackEnabled;
     public final boolean initFallbackMode;
     public final int healthCheckIntervalInSec;
-    public final int domainDataTTL;
     private final int poolSize;
     private final Map<String, String> properties;
     private final String host;
@@ -24,7 +23,6 @@ public class ArcusClientConfig {
         this.host = properties.getOrDefault(HIBERNATE_CACHE_ARCUS_HOST, "localhost:2181");
         this.serviceCode = properties.getOrDefault(HIBERNATE_CACHE_ARCUS_SERVICE_CODE, "");
         this.poolSize = Integer.parseInt(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_POOL_SIZE, "1"));
-        this.domainDataTTL = Integer.parseInt(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_DOMAIN_DATA_TTL, "0"));
 
         this.fallbackEnabled = Boolean.parseBoolean(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_FALLBACK_ENABLED, "true"));
         this.initFallbackMode = Boolean.parseBoolean(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_INIT_FALLBACK_MODE, "false"));

--- a/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusProperties.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusProperties.java
@@ -10,4 +10,5 @@ public class HibernateArcusProperties {
     public static final String HIBERNATE_CACHE_ARCUS_RECONNECT_INTERVAL_IN_SEC = "hibernate.cache.arcus.reconnectIntervalInSec";
     public static final String HIBERNATE_CACHE_ARCUS_OP_TIMEOUT = "hibernate.cache.arcus.opTimeout";
     public static final String HIBERNATE_CACHE_ARCUS_EVICTION_REGION_GROUP_ON_CACHE_UPDATE = "hibernate.cache.arcus.domainData.evictionRegionGroupOnCacheUpdate";
+    public static final String HIBERNATE_CACHE_ARCUS_DOMAIN_DATA_TTL = "hibernate.cache.arcus.domainData.ttl";
 }

--- a/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusProperties.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusProperties.java
@@ -10,5 +10,5 @@ public class HibernateArcusProperties {
     public static final String HIBERNATE_CACHE_ARCUS_RECONNECT_INTERVAL_IN_SEC = "hibernate.cache.arcus.reconnectIntervalInSec";
     public static final String HIBERNATE_CACHE_ARCUS_OP_TIMEOUT = "hibernate.cache.arcus.opTimeout";
     public static final String HIBERNATE_CACHE_ARCUS_EVICTION_REGION_GROUP_ON_CACHE_UPDATE = "hibernate.cache.arcus.domainData.evictionRegionGroupOnCacheUpdate";
-    public static final String HIBERNATE_CACHE_ARCUS_DOMAIN_DATA_TTL = "hibernate.cache.arcus.domainData.ttl";
+    public static final String HIBERNATE_CACHE_ARCUS_DOMAIN_DATA_TTL = "hibernate.cache.arcus.domainData.ttl.sec";
 }

--- a/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusStorageConfig.java
+++ b/src/main/java/com/devookim/hibernatearcus/config/HibernateArcusStorageConfig.java
@@ -4,12 +4,17 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 
+import static com.devookim.hibernatearcus.config.HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_DOMAIN_DATA_TTL;
+import static com.devookim.hibernatearcus.config.HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_EVICTION_REGION_GROUP_ON_CACHE_UPDATE;
+
 public class HibernateArcusStorageConfig {
 
     public final HashSet<String> evictionRegionGroupOnCacheUpdate;
+    public final int domainDataTTL;
 
     public HibernateArcusStorageConfig(Map<String, String> properties) {
         evictionRegionGroupOnCacheUpdate = new HashSet<>();
-        Collections.addAll(evictionRegionGroupOnCacheUpdate, properties.getOrDefault(HibernateArcusProperties.HIBERNATE_CACHE_ARCUS_EVICTION_REGION_GROUP_ON_CACHE_UPDATE, "").split(","));
+        domainDataTTL = Integer.parseInt(properties.getOrDefault(HIBERNATE_CACHE_ARCUS_DOMAIN_DATA_TTL, "0"));
+        Collections.addAll(evictionRegionGroupOnCacheUpdate, properties.getOrDefault(HIBERNATE_CACHE_ARCUS_EVICTION_REGION_GROUP_ON_CACHE_UPDATE, "").split(","));
     }
 }

--- a/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/DomainDataHibernateArcusStorageAccess.java
@@ -24,7 +24,7 @@ public class DomainDataHibernateArcusStorageAccess extends HibernateArcusStorage
                                                  String regionName,
                                                  HibernateArcusStorageConfig storageAccessConfig,
                                                  DomainDataRegionConfig regionConfig) {
-        super(arcusClientFactory, regionName);
+        super(arcusClientFactory, regionName, storageAccessConfig.domainDataTTL);
         this.storageAccessConfig = storageAccessConfig;
         this.entityClassName = RegionConfigUtil.getEntityClassName(regionConfig);
         this.accessType = RegionConfigUtil.getAccessTypeOfEntityCaching(regionConfig);

--- a/src/main/java/com/devookim/hibernatearcus/storage/HibernateArcusStorageAccess.java
+++ b/src/main/java/com/devookim/hibernatearcus/storage/HibernateArcusStorageAccess.java
@@ -8,13 +8,19 @@ import org.slf4j.Logger;
 
 public class HibernateArcusStorageAccess implements DomainDataStorageAccess {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(HibernateArcusStorageAccess.class);
-    private HibernateArcusClientFactory arcusClientFactory;
+    private final HibernateArcusClientFactory arcusClientFactory;
     protected final String CACHE_REGION;
+    private int ttl = 0;
 
     public HibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory, String prefix) {
         super();
         this.arcusClientFactory = arcusClientFactory;
         this.CACHE_REGION = prefix;
+    }
+
+    public HibernateArcusStorageAccess(HibernateArcusClientFactory arcusClientFactory, String prefix, int ttl) {
+        this(arcusClientFactory, prefix);
+        this.ttl = ttl;
     }
 
     protected String generateKey(Object key) {
@@ -55,7 +61,7 @@ public class HibernateArcusStorageAccess implements DomainDataStorageAccess {
 
         String generatedKey = generateKey(key);
         try {
-            arcusClientFactory.getClientPool().set(generatedKey, 0, value).get();
+            arcusClientFactory.getClientPool().set(generatedKey, ttl, value).get();
             log.trace("put key:{} value: {}", generatedKey, value);
         } catch (Exception e) {
             log.error("fallbackEnabled: {} key: {} errorMsg: {}", arcusClientFactory.fallbackEnabled, generatedKey, e.getMessage());


### PR DESCRIPTION
### Issue: https://github.com/Kims-DeveloperGroup/hibernate-arcus/issues/11 

### Changes
DomainData entity is set with ttl injected by a property **_hibernate.cache.arcus.domainData.ttl.sec_**
default value: 0 (permanent)

